### PR TITLE
add event handlers and parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Change log:
 
+### "2.0.0-beta.7"
++ Add "mouseenter" & "mouseleave" handlers to enable viewing the extended values for "eDec", "scaleDivisor" & "nSep" options.
++ Add third parameter to the "autoGet" call in "onFocusOutAndMouseLeave" function
+
 ### "2.0.0-beta.6"
 + Rename the `localOutput` setting to `outputType`, and add an option 'number' that makes `getLocalized` always return a Number, instead of a string.
 + Modify the `get` function so that it always returns a valid Number or string representing a number that Javascript can interpret.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autonumeric",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.7",
   "description": "autoNumeric is a jQuery plugin that automatically formats currency (money) and numbers as you type on form inputs. It supports most international numeric formats and currency signs including those used in Europe, North and South America, Asia and India's' lakhs.",
   "main": "src/autoNumeric.js",
   "typings": "typings.d.ts",

--- a/src/autoNumeric.js
+++ b/src/autoNumeric.js
@@ -2,7 +2,7 @@
 * autoNumeric.js
 * @author: Bob Knothe
 * @contributors: Sokolov Yura and other Github users
-* @version: 2.0 - 2016-11-27 UTC 11:00
+* @version: 2.0 - 2016-12-01 UTC 21:00
 *
 * Created by Robert J. Knothe on 2009-08-09. Please report any bugs to https://github.com/BobKnothe/autoNumeric
 *
@@ -2288,37 +2288,39 @@ if (typeof define === 'function' && define.amd) {
      * @param holder
      * @returns {*}
      */
-    function onFocusIn($this, holder) {
-        $this.on('focusin.autoNumeric', () => {
+    function onFocusInAndMouseEnter($this, holder) {
+        $this.on('focusin.autoNumeric mouseenter.autoNumeric', e => {
             holder = getHolder($this);
             const $settings = holder.settingsClone;
-            $settings.onOff = true;
+            if ( e.type === 'focusin' || e.type === 'mouseenter' && !$this.is(':focus') && $settings.wEmpty === 'focus') {
+                $settings.onOff = true;
 
-            if ($settings.nBracket !== null && $settings.aNeg !== '') {
-                $this.val(negativeBracket($this.val(), $settings));
-            }
+                if ($settings.nBracket !== null && $settings.aNeg !== '') {
+                    $this.val(negativeBracket($this.val(), $settings));
+                }
 
-            let result;
-            if ($settings.eDec) {
-                $settings.mDec = $settings.eDec;
-                $this.autoNumeric('set', $settings.rawValue);
-            } else if ($settings.scaleDivisor) {
-                $settings.mDec = $settings.oDec;
-                $this.autoNumeric('set', $settings.rawValue);
-            } else if ($settings.nSep) {
-                $settings.aSep = '';
-                $settings.aSign = '';
-                $settings.aSuffix = '';
-                $this.autoNumeric('set', $settings.rawValue);
-            } else if ((result = autoStrip($this.val(), $settings)) !== $settings.rawValue) {
-                $this.autoNumeric('set', result);
-            }
+                let result;
+                if ($settings.eDec) {
+                    $settings.mDec = $settings.eDec;
+                    $this.autoNumeric('set', $settings.rawValue);
+                } else if ($settings.scaleDivisor) {
+                    $settings.mDec = $settings.oDec;
+                    $this.autoNumeric('set', $settings.rawValue);
+                } else if ($settings.nSep) {
+                    $settings.aSep = '';
+                    $settings.aSign = '';
+                    $settings.aSuffix = '';
+                    $this.autoNumeric('set', $settings.rawValue);
+                } else if ((result = autoStrip($this.val(), $settings)) !== $settings.rawValue) {
+                    $this.autoNumeric('set', result);
+                }
 
-            holder.inVal = $this.val();
-            holder.lastVal = holder.inVal;
-            const onEmpty = checkEmpty(holder.inVal, $settings, true);
-            if ((onEmpty !== null && onEmpty !== '') && $settings.wEmpty === 'focus') {
-                $this.val(onEmpty);
+                holder.inVal = $this.val();
+                holder.lastVal = holder.inVal;
+                const onEmpty = checkEmpty(holder.inVal, $settings, true);
+                if ((onEmpty !== null && onEmpty !== '') && $settings.wEmpty === 'focus') {
+                    $this.val(onEmpty);
+                }
             }
         });
 
@@ -2479,81 +2481,83 @@ if (typeof define === 'function' && define.amd) {
      * @param holder
      * @returns {*}
      */
-    function onFocusOut($this, holder) {
-        $this.on('focusout.autoNumeric', () => {
-            holder = getHolder($this);
-            let value = $this.val();
-            const origValue = value;
-            const settings = holder.settingsClone;
-            settings.onOff = false;
-            if (settings.aStor) {
-                autoSave($this, settings, 'set');
-            }
-
-            if (settings.nSep === true) {
-                settings.aSep = settings.oSep;
-                settings.aSign = settings.oSign;
-                settings.aSuffix = settings.oSuffix;
-            }
-
-            if (settings.eDec !== null) {
-                settings.mDec = settings.oDec;
-                settings.aPad = settings.oPad;
-                settings.nBracket = settings.oBracket;
-            }
-
-            value = autoStrip(value, settings);
-            if (value !== '') {
-                if (settings.trailingNegative) {
-                    value = '-' + value;
-                    settings.trailingNegative = false;
+    function onFocusOutAndMouseLeave($this, holder) {
+        $this.on('focusout.autoNumeric mouseleave.autoNumeric', () => {
+            if (!$this.is(':focus')) {
+                holder = getHolder($this);
+                let value = $this.val();
+                const origValue = value;
+                const settings = holder.settingsClone;
+                settings.onOff = false;
+                if (settings.aStor) {
+                    autoSave($this, settings, 'set');
                 }
 
-                const [minTest, maxTest] = autoCheck(value, settings);
-                if (checkEmpty(value, settings) === null && minTest && maxTest) { //TODO `checkEmpty` is missing the third parameter
-                    value = fixNumber(value, settings);
-                    settings.rawValue = value;
+                if (settings.nSep === true) {
+                    settings.aSep = settings.oSep;
+                    settings.aSign = settings.oSign;
+                    settings.aSuffix = settings.oSuffix;
+                }
 
-                    if (settings.scaleDivisor) {
-                        value = value / settings.scaleDivisor;
-                        value = value.toString();
+                if (settings.eDec !== null) {
+                    settings.mDec = settings.oDec;
+                    settings.aPad = settings.oPad;
+                    settings.nBracket = settings.oBracket;
+                }
+
+                value = autoStrip(value, settings);
+                if (value !== '') {
+                    if (settings.trailingNegative) {
+                        value = '-' + value;
+                        settings.trailingNegative = false;
                     }
 
-                    settings.mDec = (settings.scaleDivisor && settings.scaleDecimal)?+settings.scaleDecimal:settings.mDec;
-                    value = autoRound(value, settings);
-                    value = presentNumber(value, settings);
+                    const [minTest, maxTest] = autoCheck(value, settings);
+                    if (checkEmpty(value, settings, false) === null && minTest && maxTest) {
+                        value = fixNumber(value, settings);
+                        settings.rawValue = value;
+
+                        if (settings.scaleDivisor) {
+                            value = value / settings.scaleDivisor;
+                            value = value.toString();
+                        }
+
+                        settings.mDec = (settings.scaleDivisor && settings.scaleDecimal) ? +settings.scaleDecimal : settings.mDec;
+                        value = autoRound(value, settings);
+                        value = presentNumber(value, settings);
+                    } else {
+                        if (!minTest) {
+                            $this.trigger('autoNumeric:minExceeded');
+                        }
+                        if (!maxTest) {
+                            $this.trigger('autoNumeric:maxExceeded');
+                        }
+
+                        value = settings.rawValue;
+                    }
                 } else {
-                    if (!minTest) {
-                        $this.trigger('autoNumeric:minExceeded');
+                    if (settings.wEmpty === 'zero') {
+                        settings.rawValue = '0';
+                        value = autoRound('0', settings);
+                    } else {
+                        settings.rawValue = '';
                     }
-                    if (!maxTest) {
-                        $this.trigger('autoNumeric:maxExceeded');
-                    }
-
-                    value = settings.rawValue;
                 }
-            } else {
-                if (settings.wEmpty === 'zero') {
-                    settings.rawValue = '0';
-                    value = autoRound('0', settings);
-                } else {
-                    settings.rawValue = '';
+
+                let groupedValue = checkEmpty(value, settings, false);
+                if (groupedValue === null) {
+                    groupedValue = autoGroup(value, settings);
                 }
-            }
 
-            let groupedValue = checkEmpty(value, settings, false);
-            if (groupedValue === null) {
-                groupedValue = autoGroup(value, settings);
-            }
+                if (groupedValue !== origValue) {
+                    groupedValue = (settings.scaleSymbol) ? groupedValue + settings.scaleSymbol : groupedValue;
+                    $this.val(groupedValue);
+                }
 
-            if (groupedValue !== origValue) {
-                groupedValue = (settings.scaleSymbol)?groupedValue + settings.scaleSymbol:groupedValue;
-                $this.val(groupedValue);
-            }
-
-            if (groupedValue !== holder.inVal) {
-                $this.change();
-                delete holder.inVal;
+                if (groupedValue !== holder.inVal) {
+                    $this.change();
+                    delete holder.inVal;
+                }
             }
         });
 
@@ -2866,8 +2870,8 @@ if (typeof define === 'function' && define.amd) {
 
                 // Add the events listeners to supported input types ("text", "hidden", "tel" and no type)
                 if ($input) {
-                    holder = onFocusIn($this, holder);
-                    holder = onFocusOut($this, holder);
+                    holder = onFocusInAndMouseEnter($this, holder);
+                    holder = onFocusOutAndMouseLeave($this, holder);
                     holder = onKeydown($this, holder);
                     holder = onKeypress($this, holder);
                     holder = onKeyup($this, holder, settings);


### PR DESCRIPTION
Add "mouseenter" & "mouseleave" handlers to enable viewing the extended
values for "eDec", "scaleDivisor" & "nSep" options.

Add third parameter to the "autoGet" call in "onFocusOutAndMouseLeave"
function